### PR TITLE
Add Travis-CI config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,3 +25,4 @@ notifications:
   email:
     on_success: change
     on_failure: always
+  slack: cloudet:rMfRKhvsbZuCIRZpTct3kBI4

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,27 @@
+sudo: required
+
+language: python
+
+python:
+    - 3.4
+
+services:
+  - docker
+
+before_install:
+- sudo apt-get update -qq
+- sudo apt-get install -y nodejs
+- docker pull jupyter/pyspark-notebook:3.2
+
+install:
+  - npm install
+
+script:
+- make test
+- make sdist
+- make install
+
+notifications:
+  email:
+    on_success: change
+    on_failure: always


### PR DESCRIPTION
Notifications other than via email will require someone with sufficient permissions to set up the other end (e.g. a Slack Integration requires a Team Administrator http://docs.travis-ci.com/user/notifications/#Slack-notifications).