### PR TITLE
[issue: 9] Converter should put converted files into "dot" folder

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,7 @@ clean:
 	@-rm -rf dist
 	@-rm -rf *.egg-info
 	@-rm -rf etc/notebooks/test_app
+	@-rm -rf etc/notebooks/local_dashboards
 	@-rm -rf node_modules
 	@-rm -rf urth_dash_js/notebook/bower_components
 	@-find . -name __pycache__ -exec rm -fr {} \;

--- a/urth/dashboard/converter/__init__.py
+++ b/urth/dashboard/converter/__init__.py
@@ -37,8 +37,9 @@ def to_php_app(notebook_fn, app_location=None, template_fn=None):
     Jupyter kernel server given in the KERNEL_SERVICE_URL environment variable
     to execute code.
 
-    :param notebook_fn:
-    :param app_location:
+    :param notebook_fn: notebook file path
+    :param app_location: output directory
+    :param template_fn: template file name
     :returns:
     '''
     # Invoke nbconvert to get the HTML

--- a/urth/dashboard/nbexts/bundle_handler.py
+++ b/urth/dashboard/nbexts/bundle_handler.py
@@ -199,7 +199,7 @@ class NewBundleHandler(IPythonHandler):
 
         :param abs_nb_path:
         '''
-        md = self._create_app_bundle(abs_nb_path, bundle_root=self.nb_dir, overwrite=True, template_fn='local.tpl')
+        md = self._create_app_bundle(abs_nb_path, bundle_root=os.path.join(self.nb_dir, 'local_dashboards'), overwrite=True, template_fn='local.tpl')
         with open(md['bundle_dir']+'/index.php', encoding="utf-8") as f:
             php = f.read()
         # Just hack the replacement of the one PHP bit for now. Would be better
@@ -211,6 +211,7 @@ class NewBundleHandler(IPythonHandler):
             fh.write(html)
         bundle_url_path = url_path_join(self.application.settings['base_url'],
             'files',
+            'local_dashboards',
             escape.url_escape(md['bundle_id'], False),
             'index.html'
         )


### PR DESCRIPTION
    Opted for a folder named "local_dashboards" so it remains visible
    in the tree, but still contains all the generated local dashboards.

(c) Copyright IBM Corp. 2015