### PR TITLE
[issue 15] Race condition in error-log enable with kernel readiness

### DIFF
--- a/urth/dashboard/converter/static/urth/dashboard.js
+++ b/urth/dashboard/converter/static/urth/dashboard.js
@@ -111,6 +111,8 @@ define(['jquery', 'Thebe', 'urth-common/error-log'], function($, Thebe, ErrorLog
 
             initThebe({
                 url: Urth.thebe_url
+            }).notebook.events.on('kernel_created.Kernel kernel_created.Session', function(e) {
+                ErrorLog.enable(window.IPython);
             });
 
             var row = getQueryParam('row');
@@ -131,8 +133,6 @@ define(['jquery', 'Thebe', 'urth-common/error-log'], function($, Thebe, ErrorLog
 
         executeAll: function() {
             thebe.run_cell(0, thebe.cells.length);
-            // have to register after first cell exec?
-            ErrorLog.enable(window.IPython);
         }
     };
 });

--- a/urth_dash_js/notebook/dashboard-common/error-log.js
+++ b/urth_dash_js/notebook/dashboard-common/error-log.js
@@ -14,27 +14,30 @@ define([
     $
 ) {
     'use strict';
-
+    var enabled = false;
     return {
         /**
          * Show IOPub errors in the JS console.
          * @param  {object} IPython    "global" IPython singleton
          */
         enable: function(IPython) {
-            var errorHandler = IPython.notebook.kernel.get_iopub_handler('error'); // save old handler
-            IPython.notebook.kernel.register_iopub_handler('error', function(msg) {
-                errorHandler(msg); // call old handler
+            if (!enabled) {
+                var errorHandler = IPython.notebook.kernel.get_iopub_handler('error'); // save old handler
+                IPython.notebook.kernel.register_iopub_handler('error', function(msg) {
+                    errorHandler(msg); // call old handler
 
-                try {
-                    // print error to console (following code as seen in Notebook's OutputArea.append_text)
-                    var data = msg.content.traceback.join('\n');
-                    data = IPython.utils.fixConsole(data);
-                    data = IPython.utils.fixCarriageReturn(data);
-                    data = IPython.utils.autoLinkUrls(data);
-                    // `data` is HTML, print out text-only
-                    console.error($('<div/>').append(data).text());
-                } catch(e) {}
-            });
+                    try {
+                        // print error to console (following code as seen in Notebook's OutputArea.append_text)
+                        var data = msg.content.traceback.join('\n');
+                        data = IPython.utils.fixConsole(data);
+                        data = IPython.utils.fixCarriageReturn(data);
+                        data = IPython.utils.autoLinkUrls(data);
+                        // `data` is HTML, print out text-only
+                        console.error($('<div/>').append(data).text());
+                    } catch(e) {}
+                });
+                enabled = true;
+            }
         }
     };
 });


### PR DESCRIPTION
Issue #15 .    
    Wait for one of the possible kernel created events before registering
     the Error handler.

(c) Copyright IBM Corp. 2015