### PR TITLE
Compatibility update with widgets for Safari / Firefox support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,6 +65,6 @@ __pycache__/
 *.egg-info/
 etc/notebooks/*
 !etc/notebooks/*_demo
-!etc/notebooks/test/*
+!etc/notebooks/test/
 etc/ipython_notebook_config.py
 etc/notebook.json

--- a/etc/notebooks/stream_demo/meetup-streaming.ipynb
+++ b/etc/notebooks/stream_demo/meetup-streaming.ipynb
@@ -138,7 +138,7 @@
    "outputs": [],
    "source": [
     "%%html\n",
-    "<link rel=\"import\" href=\"./static/urth_components/urth-viz-chart/urth-viz-chart.html\">\n",
+    "<link rel=\"import\" href=\"urth_components/urth-viz-chart/urth-viz-chart.html\" is=\"urth-core-import\">\n",
     "\n",
     "<template is=\"urth-core-bind\" channel=\"counts\">\n",
     "    <urth-viz-chart type='bar' datarows='[[counts.data]]' columns='[[counts.columns]]' rotatelabels='30'></urth-viz-chart>\n",
@@ -201,7 +201,7 @@
    "outputs": [],
    "source": [
     "%%html\n",
-    "<link rel=\"import\" href=\"./static/urth_components/paper-input/paper-input.html\"\n",
+    "<link rel=\"import\" href=\"urth_components/paper-input/paper-input.html\"\n",
     "    is=\"urth-core-import\" package=\"PolymerElements/paper-input\">\n",
     "    \n",
     "<template is=\"urth-core-bind\" channel=\"filter\" id=\"filter-input\">\n",
@@ -249,7 +249,7 @@
    "outputs": [],
    "source": [
     "%%html\n",
-    "<link rel=\"import\" href=\"./static/urth_components/paper-card/paper-card.html\"\n",
+    "<link rel=\"import\" href=\"urth_components/paper-card/paper-card.html\"\n",
     "    is=\"urth-core-import\" package=\"PolymerElements/paper-card\">\n",
     "\n",
     "<style is=\"custom-style\">\n",
@@ -351,7 +351,7 @@
    "outputs": [],
    "source": [
     "%%html\n",
-    "<link rel=\"import\" href=\"./static/urth_components/webgl-globe/webgl-globe.html\"\n",
+    "<link rel=\"import\" href=\"urth_components/webgl-globe/webgl-globe.html\"\n",
     "  is=\"urth-core-import\" package=\"http://github.com/ibm-et/webgl-globe.git\">\n",
     "\n",
     "<template is=\"urth-core-bind\" channel=\"venues\">\n",
@@ -916,7 +916,7 @@
    "outputs": [],
    "source": [
     "%%html\n",
-    "<link rel=\"import\" href=\"./static/urth_components/paper-toggle-button/paper-toggle-button.html\"\n",
+    "<link rel=\"import\" href=\"urth_components/paper-toggle-button/paper-toggle-button.html\"\n",
     "    is=\"urth-core-import\" package=\"PolymerElements/paper-toggle-button#v1.0.10\">\n",
     "    \n",
     "<template is=\"urth-core-bind\">\n",

--- a/etc/notebooks/taxi_demo/taxi_dashboard.ipynb
+++ b/etc/notebooks/taxi_demo/taxi_dashboard.ipynb
@@ -64,14 +64,14 @@
    "outputs": [],
    "source": [
     "%%html\n",
-    "<link rel=\"import\" href=\"./static/urth_components/paper-dropdown-menu/paper-dropdown-menu.html\" is='urth-core-import' package='PolymerElements/paper-dropdown-menu'>\n",
-    "<link rel=\"import\" href=\"./static/urth_components/paper-menu/paper-menu.html\" is='urth-core-import' package='PolymerElements/paper-menu'>\n",
-    "<link rel=\"import\" href=\"./static/urth_components/paper-item/paper-item.html\" is='urth-core-import' package='PolymerElements/paper-item'>\n",
-    "<link rel=\"import\" href=\"./static/urth_components/paper-slider/paper-slider.html\" is='urth-core-import' package='PolymerElements/paper-slider'>\n",
-    "<link rel=\"import\" href=\"./static/urth_components/google-map/google-map.html\" is='urth-core-import' package='GoogleWebComponents/google-map'>\n",
-    "<link rel=\"import\" href=\"./static/urth_components/google-map/google-map-marker.html\" is='urth-core-import' package='GoogleWebComponents/google-map'>\n",
-    "<link rel=\"import\" href=\"./static/urth_components/urth-viz-table/urth-viz-table.html\">\n",
-    "<link rel=\"import\" href=\"./static/urth_components/urth-viz-chart/urth-viz-chart.html\">\n",
+    "<link rel=\"import\" href=\"urth_components/paper-dropdown-menu/paper-dropdown-menu.html\" is='urth-core-import' package='PolymerElements/paper-dropdown-menu'>\n",
+    "<link rel=\"import\" href=\"urth_components/paper-menu/paper-menu.html\" is='urth-core-import' package='PolymerElements/paper-menu'>\n",
+    "<link rel=\"import\" href=\"urth_components/paper-item/paper-item.html\" is='urth-core-import' package='PolymerElements/paper-item'>\n",
+    "<link rel=\"import\" href=\"urth_components/paper-slider/paper-slider.html\" is='urth-core-import' package='PolymerElements/paper-slider'>\n",
+    "<link rel=\"import\" href=\"urth_components/google-map/google-map.html\" is='urth-core-import' package='GoogleWebComponents/google-map'>\n",
+    "<link rel=\"import\" href=\"urth_components/google-map/google-map-marker.html\" is='urth-core-import' package='GoogleWebComponents/google-map'>\n",
+    "<link rel=\"import\" href=\"urth_components/urth-viz-table/urth-viz-table.html\" is='urth-core-import'>\n",
+    "<link rel=\"import\" href=\"urth_components/urth-viz-chart/urth-viz-chart.html\" is='urth-core-import'>\n",
     "\n",
     "<style>\n",
     "    div.output_wrapper {\n",
@@ -359,7 +359,7 @@
      "dashboard": {
       "layout": {
        "col": 0,
-       "height": 11,
+       "height": 10,
        "row": 29,
        "width": 12
       }
@@ -385,7 +385,7 @@
       "layout": {
        "col": 0,
        "height": 2,
-       "row": 40,
+       "row": 39,
        "width": 8
       }
      }
@@ -433,7 +433,7 @@
       "layout": {
        "col": 1,
        "height": 3,
-       "row": 42,
+       "row": 41,
        "width": 11
       }
      }
@@ -471,7 +471,7 @@
       "layout": {
        "col": 7,
        "height": 17,
-       "row": 45,
+       "row": 44,
        "width": 5
       }
      }
@@ -496,8 +496,8 @@
      "dashboard": {
       "layout": {
        "col": 0,
-       "height": 17,
-       "row": 45,
+       "height": 18,
+       "row": 44,
        "width": 7
       }
      }
@@ -510,6 +510,20 @@
     "    <urth-viz-chart type='bar' datarows='[[topEarners.data]]' columns='[[topEarners.columns]]' rotatelabels='30'></urth-viz-chart>\n",
     "</template>"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true,
+    "urth": {
+     "dashboard": {
+      "hidden": true
+     }
+    }
+   },
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/etc/notebooks/test/test_layout_declarativewidgets.ipynb
+++ b/etc/notebooks/test/test_layout_declarativewidgets.ipynb
@@ -1,0 +1,159 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "urth": {
+     "dashboard": {
+      "layout": {
+       "col": 0,
+       "height": 3,
+       "row": 0,
+       "width": 12
+      }
+     }
+    }
+   },
+   "source": [
+    "# Declarative Widgets in a Dashboard Layout Test"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "urth": {
+     "dashboard": {
+      "layout": {
+       "col": 0,
+       "height": 4,
+       "row": 3,
+       "width": 3
+      }
+     }
+    }
+   },
+   "source": [
+    "Here is a `paper-input` widget from the Polymer catalog."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "urth": {
+     "dashboard": {
+      "layout": {
+       "col": 3,
+       "height": 4,
+       "row": 3,
+       "width": 9
+      }
+     }
+    }
+   },
+   "outputs": [],
+   "source": [
+    "%%html\n",
+    "<link rel='import' href='urth_components/paper-input/paper-input.html' \n",
+    "        is='urth-core-import' package='PolymerElements/paper-input'>\n",
+    "\n",
+    "<paper-input label=\"Enter some text\"></paper-input>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "urth": {
+     "dashboard": {
+      "layout": {
+       "col": 0,
+       "height": 4,
+       "row": 7,
+       "width": 3
+      }
+     }
+    }
+   },
+   "source": [
+    "And here is a `paper-dropdown-menu` widget from the Polymer catalog."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "urth": {
+     "dashboard": {
+      "layout": {
+       "col": 3,
+       "height": 4,
+       "row": 7,
+       "width": 4
+      }
+     }
+    }
+   },
+   "outputs": [],
+   "source": [
+    "%%html\n",
+    "<link rel=\"import\" href=\"urth_components/paper-dropdown-menu/paper-dropdown-menu.html\" \n",
+    "        is='urth-core-import' package='PolymerElements/paper-dropdown-menu'>\n",
+    "<link rel=\"import\" href=\"urth_components/paper-item/paper-item.html\" \n",
+    "        is='urth-core-import' package='PolymerElements/paper-item'>\n",
+    "\n",
+    "<paper-dropdown-menu label=\"Select Something\" noink>\n",
+    "    <paper-menu class=\"dropdown-content\" attr-for-selected=\"label\">\n",
+    "        <paper-item label=\"A\">A</paper-item>    \n",
+    "        <paper-item label=\"B\">B</paper-item>    \n",
+    "        <paper-item label=\"C\">C</paper-item>    \n",
+    "    </paper-menu>\n",
+    "</paper-dropdown-menu>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true,
+    "urth": {
+     "dashboard": {
+      "hidden": true
+     }
+    }
+   },
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "celltoolbar": "Section",
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.4.3"
+  },
+  "urth": {
+   "dashboard": {
+    "cellMargin": 10,
+    "defaultCellHeight": 20,
+    "maxColumns": 12
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/urth/dashboard/converter/static/main.js
+++ b/urth/dashboard/converter/static/main.js
@@ -45,7 +45,7 @@ requirejs(['urth/dashboard'], function(Dashboard) {
         requirejs(['urth_widgets/js/init/init'], function(widgetInit) {
             // Initialize the widgets which we assume is blocking here (which it
             // is as of right now ...)
-            widgetInit('static/urth_components');
+            widgetInit('static/');
             // Now that all dependencies are ready, execute everything
             Dashboard.executeAll();
         }, function(err) {


### PR DESCRIPTION
To fix Safari and Firefox support in declarative widgets (jupyter-incubator/declarativewidgets#21) the path passed to the widget init function needed to change (jupyter-incubator/declarativewidgets#28).

This PR contains the path change in the dashboard `main.js` and a test notebook. It should not be merged until after the PR above is merged for widgets.