### PR TITLE
Deploy As -> Local fails if notebook is read only

### DIFF
--- a/urth_dash_js/notebook/deploy-menu/deploy-menu.js
+++ b/urth_dash_js/notebook/deploy-menu/deploy-menu.js
@@ -26,9 +26,13 @@ define([
         var w = window.open('', IPython._target);
         if (IPython.notebook.dirty) {
             // Delay requesting the bundle until a dirty notebook is saved
-            IPython.notebook.save_notebook().then(function() {
-                w.location = url;
-            });
+            var d = IPython.notebook.save_notebook();
+            // https://github.com/jupyter/notebook/issues/618
+            if(d) {
+                d.then(function() {
+                    w.location = url;
+                });
+            }
         } else {
             w.location = url;
         }


### PR DESCRIPTION
The save_notebook call winds up returning a null / undefined instead of a promise. Check to see if we're actually getting a promise back or not before invoking then(). (Maybe should be fixed upstream in notebook JS to always return the promise.)