### PR TITLE
[Issue 38] Wait for widgets loaded promise before running cells

### DIFF
--- a/urth/dashboard/converter/static/main.js
+++ b/urth/dashboard/converter/static/main.js
@@ -43,11 +43,11 @@ requirejs(['urth/dashboard'], function(Dashboard) {
         // but we don't have another way to detect and determine if / how these
         // should be setup at the moment.
         requirejs(['urth_widgets/js/init/init'], function(widgetInit) {
-            // Initialize the widgets which we assume is blocking here (which it
-            // is as of right now ...)
-            widgetInit('static/');
-            // Now that all dependencies are ready, execute everything
-            Dashboard.executeAll();
+            // Initialize the widgets
+            widgetInit('static/').then(function() {
+                // Now that all dependencies are ready, execute everything
+                Dashboard.executeAll();
+            });
         }, function(err) {
             console.warn('urth widgets not available');
             // Continue with execution of cells

--- a/urth/dashboard/converter/static/urth/dashboard.js
+++ b/urth/dashboard/converter/static/urth/dashboard.js
@@ -50,6 +50,9 @@ define(['jquery', 'Thebe', 'urth-common/error-log'], function($, Thebe, ErrorLog
         // override this function since it messes with images (invoking jquery.resizable on them)
         IPython.OutputArea.prototype._dblclick_to_reset_size = function() {};
 
+        // finally, let's start the kernel (rather than waiting for it to be lazily loaded)
+        thebe.start_kernel(function() {});
+
         return thebe;
     }
 


### PR DESCRIPTION
Works in conjunction with [this PR](https://github.com/jupyter-incubator/declarativewidgets/pull/52) from the declarativewidgets repo.

Fixes issue #38.

(c) Copyright IBM Corp. 2015