### PR TITLE
Adopt jupyter versioning approach, package name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
 
-.PHONY: build clean dev help sdist test install remote
+.PHONY: build clean configs demo dev dev-with-widgets help install js sdist test
 
 help:
 	@echo 'Host commands:'
@@ -97,15 +97,11 @@ install:
 			$(CMD)'
 
 sdist: REPO?=cloudet/pyspark-notebook-bower
-sdist: RELEASE?=
-sdist: BUILD_NUMBER?=0
-sdist: GIT_COMMIT?=HEAD
 sdist: js
 	@docker run -it --rm \
 		-v `pwd`:/src \
 		$(REPO) bash -c 'cp -r /src /tmp/src && \
 			cd /tmp/src && \
-			echo "$(BUILD_NUMBER)-$(GIT_COMMIT)" > VERSION && \
 			python setup.py sdist && \
 			cp -r dist /src'
 

--- a/setup.py
+++ b/setup.py
@@ -8,8 +8,15 @@ from setuptools.command.install import install
 from IPython.html.nbextensions import install_nbextension
 from IPython.html.services.config import ConfigManager
 
-VERSION_FILE = os.path.join(os.path.dirname(__file__), 'VERSION')
-EXT_DIR = os.path.join(os.path.dirname(__file__), 'urth_dash_js')
+# Get location of this file at runtime
+HERE = os.path.abspath(os.path.dirname(__file__))
+
+# Eval the version tuple and string from the source
+VERSION_NS = {}
+with open(os.path.join(HERE, 'urth/dashboard/_version.py')) as f:
+    exec(f.read(), {}, VERSION_NS)
+
+EXT_DIR = os.path.join(HERE, 'urth_dash_js')
 SERVER_EXT_CONFIG = "c.NotebookApp.server_extensions.append('urth.dashboard.nbexts')"
 
 class InstallCommand(install):
@@ -38,24 +45,12 @@ class InstallCommand(install):
                 fh.write('c = get_config()\n')
                 fh.write(SERVER_EXT_CONFIG)
 
-# Apply version to build
-VERSION = '0.1'
-if os.path.isfile(VERSION_FILE):
-    # CI build, read metadata and append
-    with open(VERSION_FILE, 'r') as fh:
-        BUILD_INFO = fh.readline().strip()
-    BUILD_NUMBER, _ = BUILD_INFO.split('-')
-    VERSION += '.dev' + BUILD_NUMBER
-else:
-    # Local development build
-    VERSION += '.dev0'
-
 setup(
-    name='urth-dash-nbexts',
+    name='jupyter_dashboards',
     author='Jupyter Community',
     maintainer='Jupyter Community',
     description='IPython / Jupyter extensions to enable dashboard creation and deployment',
-    version=VERSION,
+    version=VERSION_NS['__version__'],
     license='BSD',
     platforms=['IPython Notebook 3.x'],
     packages=[

--- a/urth/dashboard/_version.py
+++ b/urth/dashboard/_version.py
@@ -1,0 +1,5 @@
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+
+version_info = (0, 1, 0, 'dev')
+__version__ = '.'.join(map(str, version_info))


### PR DESCRIPTION
WIP until we decide naming.

Versioning follows what notebook and other Jupyter components use. At first major/minor/patch release time, a manual commit is added to remove the `dev` part of the version tuple (0.1.0). 

https://github.com/jupyter/notebook/commit/b55157282a2f56be589eb9c2558e7840e1df552c

That commit is branched (0.1.x) and  tagged (0.1.0) for package build and release on pypi. Then another commit is immediately pushed on master with the `dev` added back and the appropriate part of the version number bumped (0.2.0.dev).

Important patches are made against the major/minor branch and tagged at release time. The same patches are put in master.

