### PR TITLE
[issue 123] View menu items and toolbar switcher should use consistent naming

### DIFF
--- a/urth_dash_js/notebook/dashboard-view/dashboard-actions.js
+++ b/urth_dash_js/notebook/dashboard-view/dashboard-actions.js
@@ -178,13 +178,13 @@ define([
             handler: function() { toggleDashboardMode(STATE_NOTEBOOK); }
         };
         var layoutView = {
-            help: 'Layout view. Size and position dashboard cells.',
+            help: 'Dashboard Layout. Size and position dashboard cells.',
             icon: 'fa-th-large',
             help_index: '',
             handler: function() { toggleDashboardMode(STATE_DASHBOARD_AUTH); }
         };
         var dashboardView = {
-            help: 'Dashboard view. Preview the dashboard.',
+            help: 'Dashboard Preview. Preview the dashboard.',
             icon: 'fa-dashboard',
             help_index: '',
             handler: function() { toggleDashboardMode(STATE_DASHBOARD_VIEW); }

--- a/urth_dash_js/notebook/dashboard-view/view-menu.html
+++ b/urth_dash_js/notebook/dashboard-view/view-menu.html
@@ -1,10 +1,10 @@
 <!-- Dashboard view menu items -->
-<li id="urth-notebook-view" class="urth-dashboard-menu-item" title="Notebook view. Edit the code.">
+<li id="urth-notebook-view" class="urth-dashboard-menu-item" title="Edit the code.">
     <a href="#">Notebook</a>
 </li>
-<li id="urth-dashboard-auth" class="urth-dashboard-menu-item" title="Layout view. Size and position dashboard cells.">
-    <a href="#">Layout</a>
+<li id="urth-dashboard-auth" class="urth-dashboard-menu-item" title="Size and position dashboard cells.">
+    <a href="#">Dashboard Layout</a>
 </li>
-<li id="urth-dashboard-view" class="urth-dashboard-menu-item" title="Dashboard view. Preview the dashboard.">
-    <a href="#">Dashboard</a>
+<li id="urth-dashboard-view" class="urth-dashboard-menu-item" title="Preview the dashboard.">
+    <a href="#">Dashboard Preview</a>
 </li>

--- a/urth_dash_js/notebook/dashboard-view/view-menu.html
+++ b/urth_dash_js/notebook/dashboard-view/view-menu.html
@@ -3,8 +3,8 @@
     <a href="#">Notebook</a>
 </li>
 <li id="urth-dashboard-auth" class="urth-dashboard-menu-item">
-    <a href="#">Layout Dashboard</a>
+    <a href="#">Layout</a>
 </li>
 <li id="urth-dashboard-view" class="urth-dashboard-menu-item">
-    <a href="#">View Dashboard</a>
+    <a href="#">Dashboard</a>
 </li>

--- a/urth_dash_js/notebook/dashboard-view/view-menu.html
+++ b/urth_dash_js/notebook/dashboard-view/view-menu.html
@@ -1,10 +1,10 @@
 <!-- Dashboard view menu items -->
-<li id="urth-notebook-view" class="urth-dashboard-menu-item">
+<li id="urth-notebook-view" class="urth-dashboard-menu-item" title="Notebook view. Edit the code.">
     <a href="#">Notebook</a>
 </li>
-<li id="urth-dashboard-auth" class="urth-dashboard-menu-item">
+<li id="urth-dashboard-auth" class="urth-dashboard-menu-item" title="Layout view. Size and position dashboard cells.">
     <a href="#">Layout</a>
 </li>
-<li id="urth-dashboard-view" class="urth-dashboard-menu-item">
+<li id="urth-dashboard-view" class="urth-dashboard-menu-item" title="Dashboard view. Preview the dashboard.">
     <a href="#">Dashboard</a>
 </li>


### PR DESCRIPTION
  Take "view" out of the view menu's actions. For #123.

(c) Copyright IBM Corp. 2015