### PR TITLE
[Issue 116]: Add system tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,6 +66,7 @@ __pycache__/
 etc/notebooks/*
 !etc/notebooks/*_demo
 !etc/notebooks/test/
+!etc/notebooks/system-test/
 !etc/notebooks/*_demo/*
 !etc/notebooks/*_tutorial
 !etc/notebooks/index.ipynb
@@ -74,3 +75,8 @@ etc/notebooks/*_demo/.dashboard_cache
 etc/notebooks/*_demo/.ipynb_checkpoints
 etc/ipython_notebook_config.py
 etc/notebook.json
+
+# System testing
+**/*/selenium.log
+**/*/selenium.jar
+**/*/selenium.pid

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,10 @@ python:
 services:
   - docker
 
+addons:
+  sauce_connect:
+    no_ssl_bump_domains: all
+
 before_install:
 - sudo apt-get update -qq
 - sudo apt-get install -y nodejs
@@ -22,9 +26,14 @@ script:
 - make sdist
 - make install-python2
 - make install-python3
+- make system-test-remote
 
 notifications:
   email:
     on_success: change
     on_failure: always
   slack: cloudet:rMfRKhvsbZuCIRZpTct3kBI4
+
+branches:
+  only:
+    - master

--- a/Makefile
+++ b/Makefile
@@ -1,19 +1,21 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
 
-.PHONY: build clean configs demo dev dev-with-widgets help install js sdist test
+.PHONY: build clean configs demo dev dev-with-widgets help install js sdist test system-test system-test-remote
 PYTHON?=python3
 PYTHON2_SETUP?=source activate python2; pip install ipython[notebook]==3.2;
 
 help:
 	@echo 'Host commands:'
-	@echo '           clean - clean built files'
-	@echo '            demo - start notebook server with stable dashboard / widget extensions'
-	@echo '             dev - start notebook server in a container with source mounted'
-	@echo 'dev-with-widgets - like dev, but with stable declarativewidgets installed'
-	@echo '         install - install latest sdist into a container'
-	@echo '           sdist - build a source distribution into dist/'
-	@echo '            test - run unit tests within a container'
+	@echo '             clean - clean built files'
+	@echo '              demo - start notebook server with stable dashboard / widget extensions'
+	@echo '               dev - start notebook server in a container with source mounted'
+	@echo '  dev-with-widgets - like dev, but with stable declarativewidgets installed'
+	@echo '           install - install latest sdist into a container'
+	@echo '             sdist - build a source distribution into dist/'
+	@echo '              test - run unit tests within a container'
+	@echo ' system-test-local - run system tests locally'
+	@echo 'system-test-remote - run system tests remotely on sauce labs, you must export SAUCE_USERNAME and SAUCE_ACCESS_KEY as environment variables'
 
 configs:
 # Make copies so that we don't volume mount git controlled files which will
@@ -40,9 +42,11 @@ js:
 
 demo: NB_HOME?=/home/jovyan/.ipython
 demo: REPO?=cloudet/pyspark-notebook-bower
+demo: OPTIONS?=--rm -it
+demo: SERVER_NAME?=urth_dashboards_demo_server
 demo: CMD?=ipython notebook --no-browser --port 8888 --ip="*"
 demo: configs
-	@docker run -it --rm \
+	@docker run $(OPTIONS) --name $(SERVER_NAME) \
 		-p 9500:8888 \
 		-v `pwd`:/dashboards \
 		-v `pwd`/../declarativewidgets:/declarativewidgets \
@@ -64,10 +68,12 @@ dev-python3: _dev
 _dev: NB_HOME?=/home/jovyan/.ipython
 _dev: REPO?=cloudet/pyspark-notebook-bower
 _dev: AUTORELOAD?=no
+_dev: OPTIONS?=--rm -it
+_dev: SERVER_NAME?=urth_dashboards_dev_server
 _dev: CMD?=sh -c "python --version; ipython notebook --no-browser --port 8888 --ip='*'"
 _dev: configs js
 	# Need to use two commands here to allow for activation of multiple python versions
-	@docker run -it --rm \
+	@docker run $(OPTIONS) --name $(SERVER_NAME) \
 		-p 9500:8888 \
 		-e USE_HTTP=1 \
 		-e PASSWORD='' \
@@ -151,3 +157,42 @@ _test:
 
 release: POST_SDIST=register upload
 release: sdist
+		$(REPO) $(CMD)
+
+system-test-local: TEST_SERVER?=192.168.99.1:4444
+system-test-local: BASEURL?=http://192.168.99.100:9500
+system-test-local: TEST_TYPE?=local
+system-test-local: SETUP_COMMAND?=(cd system-test/bin; ./run-selenium.sh)
+system-test-local: TEARDOWN_COMMAND?=(cd system-test/bin; ./kill-selenium.sh)
+system-test-local: _system-test
+
+system-test-remote: TEST_TYPE?=remote
+system-test-remote: BASEURL?=http://127.0.0.1:9500
+system-test-remote: TEST_SERVER?=ondemand.saucelabs.com
+system-test-remote:
+ifdef SAUCE_USERNAME
+	@TEST_TYPE=$(TEST_TYPE) BASEURL=$(BASEURL) TEST_SERVER=$(TEST_SERVER) $(MAKE) _system-test
+else
+	@echo Skipping unit tests because Sauce Credentials were not present
+endif
+
+_system-test: SERVER_NAME?=urth_dashboards_integration_test_server
+_system-test: REPO?=cloudet/pyspark-notebook-bower
+_system-test: CMD?=bash -c 'cd /src; npm run system-test -- --baseurl $(BASEURL) --server $(TEST_SERVER) --test-type $(TEST_TYPE)'
+_system-test:
+	-@docker rm -f $(SERVER_NAME)
+	@-sh -c "$(SETUP_COMMAND)"
+	@OPTIONS=-d SERVER_NAME=$(SERVER_NAME) $(MAKE) dev
+	@echo 'Waiting 20 seconds for server to start...'
+	@sleep 20
+	@echo 'Running system integration tests...'
+	@docker run --rm -it \
+		--net=host \
+		-p 9500:8888 \
+		-e SAUCE_USERNAME=$(SAUCE_USERNAME) \
+		-e SAUCE_ACCESS_KEY=$(SAUCE_ACCESS_KEY) \
+		-e TRAVIS_JOB_NUMBER=$(TRAVIS_JOB_NUMBER) \
+		-v `pwd`:/src \
+		$(REPO) $(CMD)
+	-@docker rm -f $(SERVER_NAME)
+	@-sh -c "$(TEARDOWN_COMMAND)"

--- a/Makefile
+++ b/Makefile
@@ -180,6 +180,8 @@ _system-test: SERVER_NAME?=urth_dashboards_integration_test_server
 _system-test: REPO?=cloudet/pyspark-notebook-bower
 _system-test: CMD?=bash -c 'cd /src; npm run system-test -- --baseurl $(BASEURL) --server $(TEST_SERVER) --test-type $(TEST_TYPE)'
 _system-test:
+	@which chromedriver || (echo "chromedriver not found (brew install chromedriver)"; exit 1)
+	@which selenium-server || (echo "selenium-server not found (brew install selenium-server-standalone)"; exit 1)
 	-@docker rm -f $(SERVER_NAME)
 	@-sh -c "$(SETUP_COMMAND)"
 	@OPTIONS=-d SERVER_NAME=$(SERVER_NAME) $(MAKE) dev

--- a/README.md
+++ b/README.md
@@ -14,8 +14,6 @@ Watch from minute 41 to 51 of the [September 1st Jupyter meeting video recording
 ## What It Lacks
 
 * Robust story for independent dashboard deployment (see below)
-* Frontend tests
-* More backend tests
 * User docs / tutorials
 
 ## Runtime Requirements

--- a/etc/notebooks/system-test/Basic.ipynb
+++ b/etc/notebooks/system-test/Basic.ipynb
@@ -1,0 +1,51 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "urth": {
+     "dashboard": {
+      "layout": {
+       "col": 0,
+       "height": 4,
+       "row": 0,
+       "width": 4
+      }
+     }
+    }
+   },
+   "source": [
+    "#Markdown Cell\n",
+    "This test will look for the header above in layout view and dashboard view."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.4.3"
+  },
+  "urth": {
+   "dashboard": {
+    "cellMargin": 10,
+    "defaultCellHeight": 20,
+    "maxColumns": 12
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/package.json
+++ b/package.json
@@ -8,7 +8,13 @@
   "devDependencies": {
     "autoprefixer": "^5.2.0",
     "bower": "^1.4.1",
-    "postcss-cli": "^1.5.0"
+    "postcss-cli": "^1.5.0",
+    "mocha" :"^2.0.0",
+    "wd": "latest",
+    "chai": "latest",
+    "chai-as-promised": "latest",
+    "colors": "latest",
+    "minimist": "latest"
   },
   "config": {
     "css_nb_dir": "urth_dash_js/notebook/dashboard-view",
@@ -17,7 +23,8 @@
   "scripts": {
     "test": "make test",
     "css": "postcss --use autoprefixer $npm_package_config_css_nb_dir/*.css --dir $npm_package_config_css_nb_dir/ --config postcss-config.json && postcss --use autoprefixer $npm_package_config_css_th_dir/*.css --dir $npm_package_config_css_th_dir/ --config postcss-config.json",
-    "bower": "bower --allow-root install"
+    "bower": "bower --allow-root install",
+    "system-test": "node_modules/mocha/bin/mocha system-test/**/*-test.js --timeout 300000 --reporter spec"
   },
   "repository": {
     "type": "git",

--- a/system-test/bin/kill-selenium.sh
+++ b/system-test/bin/kill-selenium.sh
@@ -1,2 +1,4 @@
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
 kill -9 `cat selenium.pid`
 rm selenium.pid

--- a/system-test/bin/kill-selenium.sh
+++ b/system-test/bin/kill-selenium.sh
@@ -1,0 +1,2 @@
+kill -9 `cat selenium.pid`
+rm selenium.pid

--- a/system-test/bin/run-selenium.sh
+++ b/system-test/bin/run-selenium.sh
@@ -1,7 +1,5 @@
-if [ ! -e  'selenium.jar' ]
-then
-  curl http://selenium-release.storage.googleapis.com/2.48/selenium-server-standalone-2.48.2.jar -o selenium.jar
-fi
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
 
 # Kill the last running process if it exists
 if [ -e  'selenium.pid' ]
@@ -11,5 +9,5 @@ then
 fi
 
 rm selenium.log;
-java -jar selenium.jar > selenium.log 2>&1 &
+selenium-server > selenium.log 2>&1 &
 echo $! > selenium.pid

--- a/system-test/bin/run-selenium.sh
+++ b/system-test/bin/run-selenium.sh
@@ -1,0 +1,15 @@
+if [ ! -e  'selenium.jar' ]
+then
+  curl http://selenium-release.storage.googleapis.com/2.48/selenium-server-standalone-2.48.2.jar -o selenium.jar
+fi
+
+# Kill the last running process if it exists
+if [ -e  'selenium.pid' ]
+then
+  kill -9 `cat selenium.pid`
+  rm selenium.pid
+fi
+
+rm selenium.log;
+java -jar selenium.jar > selenium.log 2>&1 &
+echo $! > selenium.pid

--- a/system-test/dashboard-buttons-test.js
+++ b/system-test/dashboard-buttons-test.js
@@ -1,3 +1,6 @@
+// Copyright (c) Jupyter Development Team.
+// Distributed under the terms of the Modified BSD License.
+
 var Boilerplate = require('./utils/boilerplate');
 var boilerplate = new Boilerplate();
 /**

--- a/system-test/dashboard-buttons-test.js
+++ b/system-test/dashboard-buttons-test.js
@@ -1,0 +1,27 @@
+var Boilerplate = require('./utils/boilerplate');
+var boilerplate = new Boilerplate();
+/**
+  * Tests clicking through the dashboard buttons in the notebook toolbar.
+  */
+describe('Dashboard View Buttons', function() {
+  boilerplate.setup(this.title, '/notebooks/system-test/Basic.ipynb');
+  var dashboard = boilerplate.dashboard;
+
+  it('clicking layout view should switch to layout view', function(done) {
+    dashboard.clickLayoutViewButton();
+    dashboard.assertInLayoutView();
+    dashboard.done(done);
+  });
+
+  it('clicking notebook view should switch to notebook view', function(done) {
+    dashboard.clickNotebookViewButton();
+    dashboard.assertInNotebookView();
+    dashboard.done(done);
+  });
+
+  it('clicking dashboard view should switch to dashboard view', function(done) {
+    dashboard.clickDashboardViewButton();
+    dashboard.assertInDashboardView();
+    dashboard.done(done);
+  });
+});

--- a/system-test/dashboard-menu-test.js
+++ b/system-test/dashboard-menu-test.js
@@ -1,3 +1,6 @@
+// Copyright (c) Jupyter Development Team.
+// Distributed under the terms of the Modified BSD License.
+
 var Boilerplate = require('./utils/boilerplate');
 var boilerplate = new Boilerplate();
 /**

--- a/system-test/dashboard-menu-test.js
+++ b/system-test/dashboard-menu-test.js
@@ -1,0 +1,26 @@
+var Boilerplate = require('./utils/boilerplate');
+var boilerplate = new Boilerplate();
+/**
+  * Tests clicking through the dashboard buttons in the View menu.
+  */
+describe('Dashboard View Menu Buttons', function() {
+  boilerplate.setup(this.title, '/notebooks/system-test/Basic.ipynb');
+  var dashboard = boilerplate.dashboard;
+  it('clicking "Layout Dashboard" should switch to layout view', function(done) {
+    dashboard.clickLayoutViewMenuButton();
+    dashboard.assertInLayoutView();
+    dashboard.done(done);
+  });
+
+  it('clicking "Notebook" should switch to notebook view', function(done) {
+    dashboard.clickNotebookViewMenuButton();
+    dashboard.assertInNotebookView();
+    dashboard.done(done);
+  });
+
+  it('clicking "View Dashboard" should switch to dashboard view', function(done) {
+    dashboard.clickDashboardViewMenuButton();
+    dashboard.assertInDashboardView();
+    dashboard.done(done);
+  });
+});

--- a/system-test/utils/boilerplate.js
+++ b/system-test/utils/boilerplate.js
@@ -1,0 +1,89 @@
+var wd = require('wd');
+require('colors');
+var chai = require('chai');
+var chaiAsPromised = require('chai-as-promised');
+var parseArgs = require('minimist');
+var Dashboard =  require('./dashboard');
+
+//  Parse the args
+var args = parseArgs(process.argv);
+args.local = args['test-type'] === 'local';
+args.remote = !args.local;
+
+//  Setup chai
+chai.use(chaiAsPromised);
+chai.should();
+chaiAsPromised.transferPromiseness = wd.transferPromiseness;
+
+// Configure webdriver
+wd.configureHttp({
+    timeout: 60000,
+    retryDelay: 15000,
+    retries: 5,
+    baseUrl: args.baseurl
+});
+
+//  The browser capabilities we would like setup by selenium
+var desired = {browserName: 'chrome', platform: 'OS X 10.10'};
+desired.platform = args.platform || desired.platform;
+desired.browserName = args.browser || desired.browserName;
+desired.tags = ['dashboard', 'system-test', desired.browserName];
+// If there is a build number, include it in the desired attributes for sauce labs
+if(process.env.TRAVIS_JOB_NUMBER) {
+  desired.tunnelIdentifier = process.env.TRAVIS_JOB_NUMBER;
+  desired.build = 'dashboards-build-' + process.env.TRAVIS_JOB_NUMBER;
+}
+
+//  The selenium test server, local or remote, we will be using to test against
+var testServer = 'http://' + args.server + '/wd/hub';
+if(args.remote) {
+  testServer = 'http://' + process.env.SAUCE_USERNAME + ':' + process.env.SAUCE_ACCESS_KEY + '@' + args.server + '/wd/hub';
+}
+
+console.log('Travis job number is: ', process.env.TRAVIS_JOB_NUMBER);
+console.log('Sauce user name is not defined? ', !!process.env.SAUCE_USERNAME);
+console.log('Sauce access key is defined? ', !!process.env.SAUCE_ACCESS_KEY);
+
+/**
+  * A helper class to setup webdriver, create a browser, and dashboard objects for
+  * use within the system tests.
+  */
+var Boilerplate = function(){
+  this.browser = wd.promiseChainRemote(testServer);
+  this.dashboard = new Dashboard(wd, this.browser);
+  this.allPassed = true;
+};
+
+/**
+  * Setups the before and after calls for each of your tests. The boilerplate
+  * will start each test on startingURL, which is a relative path to the resource to load.
+  */
+Boilerplate.prototype.setup = function(testName, startingURL){
+  var that = this;
+  startingURL = startingURL ? startingURL : '/';
+  desired.name = testName ? 'Urth Dashboard System Test - ' + testName
+    : 'Urth Dashboard System Test';
+
+  before(function(done){
+    this.browser.init(desired).nodeify(done);
+  }.bind(this));
+
+  beforeEach(function(done){
+    this.browser.get(startingURL).nodeify(done);
+  }.bind(this));
+
+  after(function(done){
+    var result = this.browser.quit();
+    if(args.remote) {
+      result = result.sauceJobStatus(this.allPassed);
+    }
+    result.nodeify(done);
+  }.bind(this));
+
+  afterEach(function(done) {
+    that.allPassed = that.allPassed && (this.currentTest.state === 'passed');
+    done();
+  });
+};
+
+module.exports = Boilerplate;

--- a/system-test/utils/boilerplate.js
+++ b/system-test/utils/boilerplate.js
@@ -1,3 +1,6 @@
+// Copyright (c) Jupyter Development Team.
+// Distributed under the terms of the Modified BSD License.
+
 var wd = require('wd');
 require('colors');
 var chai = require('chai');

--- a/system-test/utils/dashboard.js
+++ b/system-test/utils/dashboard.js
@@ -1,3 +1,5 @@
+// Copyright (c) Jupyter Development Team.
+// Distributed under the terms of the Modified BSD License.
 
 /**
   * Encapsulates the features of the dashboard UI.

--- a/system-test/utils/dashboard.js
+++ b/system-test/utils/dashboard.js
@@ -1,0 +1,169 @@
+
+/**
+  * Encapsulates the features of the dashboard UI.
+  * TODO: As more features are added, this file will grow. Need to refactor
+  *       functionality into submodules to keep this file maintainable.
+  */
+var Dashboard = function(wd, browser) {
+  this.browser = browser;
+  this.wd = wd;
+  this.lastCommand = browser;
+};
+//  Represents different UI elements in the notebook/dashboard UI
+var DashboardElements = {
+  "notebookViewButton": "#urth-dashboard-view-toolbar-buttons > button:nth-of-type(1)",
+  "layoutViewButton": "#urth-dashboard-view-toolbar-buttons > button:nth-of-type(2)",
+  "dashboardViewButton": "#urth-dashboard-view-toolbar-buttons > button:nth-of-type(3)",
+  "layoutViewHelpArea" : "#notebook_panel > .help-area",
+  "jupyterHeaderContainer": "#header-container",
+  "viewMenuButton" : "ul.nav > li:nth-child(3)",
+  "notebookViewMenuButton" : "#urth-notebook-view",
+  "layoutViewMenuButton" : "#urth-dashboard-auth",
+  "dashboardViewMenuButton" : "#urth-dashboard-view"
+};
+//  Represents expressions run in the browser for verification
+var DashboardExpressions = {
+  "noJupyterHeader": "document.querySelectorAll('#notebook_panel > .help-area').length === 0"
+};
+//  Genereic error logging function for callbacks below
+var logError = function(msg,err) {
+  if(err) {
+      console.error(err, msg);
+  }
+};
+//  Timeout to check for elements
+var timeout = 20000;
+
+/**
+  * Performs a click on the Notebook View Button in the notebook toolbar.
+  * Assumes the current page is in notebook view.
+  */
+Dashboard.prototype.clickNotebookViewButton = function(){
+   this.lastCommand = this.lastCommand
+    .waitForElementByCssSelector(
+      DashboardElements.notebookViewButton, this.wd.asserters.isDisplayed, timeout,
+      logError.bind(undefined,'Could not find Notebook View Button'))
+    .elementByCssSelector(DashboardElements.notebookViewButton)
+    .click();
+    return this;
+};
+/**
+  * Performs a click on the Notebook View Button in the notebook toolbar.
+  * Assumes the current page is in notebook view.
+  */
+Dashboard.prototype.clickLayoutViewButton = function(){
+   this.lastCommand = this.lastCommand
+    .waitForElementByCssSelector(
+      DashboardElements.layoutViewButton,this.wd.asserters.isDisplayed, timeout,
+      logError.bind(undefined,'Could not find Layout View Button'))
+    .elementByCssSelector(DashboardElements.layoutViewButton)
+    .click();
+    return this;
+};
+/**
+  * Performs a click on the Notebook View Button in the notebook toolbar.
+  * Assumes the current page is in notebook view.
+  */
+Dashboard.prototype.clickDashboardViewButton = function(){
+  this.lastCommand = this.lastCommand
+    .waitForElementByCssSelector(
+      DashboardElements.dashboardViewButton, this.wd.asserters.isDisplayed, timeout,
+      logError.bind(undefined,'Could not find Dashboard View Button'))
+    .elementByCssSelector(DashboardElements.dashboardViewButton)
+    .click();
+    return this;
+};
+/**
+  * Performs a click on the Notebook View Button in the notebook toolbar.
+  * Assumes the current page is in notebook view.
+  */
+Dashboard.prototype.clickNotebookViewMenuButton = function(){
+   this.lastCommand = this.lastCommand
+     .waitForElementByCssSelector(
+       DashboardElements.viewMenuButton, this.wd.asserters.isDisplayed, timeout,
+       logError.bind(undefined,'Could not find "View" menu button'))
+     .elementByCssSelector(DashboardElements.viewMenuButton)
+     .click()
+    .waitForElementByCssSelector(
+      DashboardElements.notebookViewMenuButton, this.wd.asserters.isDisplayed, timeout,
+      logError.bind(undefined,'Could not find notebook view menu button'))
+    .elementByCssSelector(DashboardElements.notebookViewMenuButton)
+    .click();
+    return this;
+};
+/**
+  * Performs a click on the Notebook View Button in the notebook toolbar.
+  * Assumes the current page is in notebook view.
+  */
+Dashboard.prototype.clickLayoutViewMenuButton = function(){
+   this.lastCommand = this.lastCommand
+     .waitForElementByCssSelector(
+       DashboardElements.viewMenuButton, this.wd.asserters.isDisplayed, timeout,
+       logError.bind(undefined,'Could not find "View" menu button'))
+     .elementByCssSelector(DashboardElements.viewMenuButton)
+     .click()
+    .waitForElementByCssSelector(
+      DashboardElements.layoutViewMenuButton,this.wd.asserters.isDisplayed, timeout,
+      logError.bind(undefined,'Could not find layout view menu button'))
+    .elementByCssSelector(DashboardElements.layoutViewMenuButton)
+    .click();
+    return this;
+};
+/**
+  * Performs a click on the Notebook View Button in the notebook toolbar.
+  * Assumes the current page is in notebook view.
+  */
+Dashboard.prototype.clickDashboardViewMenuButton = function(){
+  this.lastCommand = this.lastCommand
+    .waitForElementByCssSelector(
+      DashboardElements.viewMenuButton, this.wd.asserters.isDisplayed, timeout,
+      logError.bind(undefined,'Could not find "View" menu button'))
+    .elementByCssSelector(DashboardElements.viewMenuButton)
+    .click()
+    .waitForElementByCssSelector(
+      DashboardElements.dashboardViewMenuButton, this.wd.asserters.isDisplayed, timeout,
+      logError.bind(undefined,'Could not find dashboard view menu button'))
+    .elementByCssSelector(DashboardElements.dashboardViewMenuButton)
+    .click();
+    return this;
+};
+
+/**
+  * Asserts the current view is the notebook view.
+  */
+Dashboard.prototype.assertInNotebookView = function(){
+  this.lastCommand = this.lastCommand
+    //  Assert there is no help area in notebook view
+    .waitForConditionInBrowser(
+      DashboardExpressions.noJupyterHeader, timeout)
+      // Assert we can see the notebook header
+    .waitForElementByCssSelector(
+      DashboardElements.jupyterHeaderContainer, this.wd.asserters.isDisplayed, timeout,
+      logError.bind(undefined,'Could not find the jupyter header'));
+    return this;
+};
+/**
+  * Asserts the current view is the layout view.
+  */
+Dashboard.prototype.assertInLayoutView = function(){
+  this.lastCommand = this.lastCommand
+    .waitForElementByCssSelector(
+      DashboardElements.layoutViewHelpArea, this.wd.asserters.isDisplayed, timeout,
+      logError.bind(undefined,'Could not find layout mode help area'));
+    return this;
+};
+/**
+  * Asserts the current view is the dashboard view.
+  */
+Dashboard.prototype.assertInDashboardView = function(){
+  this.lastCommand = this.lastCommand
+    .waitForElementByCssSelector(
+      DashboardElements.jupyterHeaderContainer, this.wd.asserters.isNotDisplayed, timeout,
+      logError.bind(undefined,'The jupyter header is diplayed'));
+    return this;
+};
+
+Dashboard.prototype.done = function(done) {
+  this.lastCommand.nodeify(done);
+};
+module.exports = Dashboard;


### PR DESCRIPTION
Make targets now include `system-test-remote` and `system-test-local` for running system tests on travis and locally. 
(c) Copyright IBM Corp. 2015