### PR TITLE
Revert to old server config technique

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,6 @@
 # Distributed under the terms of the Modified BSD License.
 
 import os
-import errno
 from setuptools import setup
 from setuptools.command.install import install
 
@@ -20,18 +19,6 @@ with open(os.path.join(HERE, 'urth/dashboard/_version.py')) as f:
 
 EXT_DIR = os.path.join(HERE, 'urth_dash_js')
 
-def makedirs(path):
-    '''
-    mkdir -p and ignore existence errors compatible with Py2/3.
-    '''
-    try:
-        os.makedirs(path)
-    except OSError as e:
-        if e.errno == errno.EEXIST and os.path.isdir(path):
-            pass
-        else:
-            raise
-
 class InstallCommand(install):
     def run(self):
         # Config managers for frontend and backend
@@ -39,8 +26,8 @@ class InstallCommand(install):
         js_cm = ConfigManager()
 
         # Ensure directories exist
-        makedirs(server_cm.config_dir)
-        makedirs(js_cm.config_dir)
+        os.makedirs(server_cm.config_dir, exist_ok=True)
+        os.makedirs(js_cm.config_dir, exist_ok=True)
 
         print('Installing Python server extension')
         install.run(self)

--- a/setup.py
+++ b/setup.py
@@ -18,35 +18,33 @@ with open(os.path.join(HERE, 'urth/dashboard/_version.py')) as f:
     exec(f.read(), {}, VERSION_NS)
 
 EXT_DIR = os.path.join(HERE, 'urth_dash_js')
+SERVER_EXT_CONFIG = "c.NotebookApp.server_extensions.append('urth.dashboard.nbexts')"
 
 class InstallCommand(install):
     def run(self):
-        # Config managers for frontend and backend
-        server_cm = ConfigManager(config_dir=jupyter_config_dir())
-        js_cm = ConfigManager()
-
-        # Ensure directories exist
-        os.makedirs(server_cm.config_dir, exist_ok=True)
-        os.makedirs(js_cm.config_dir, exist_ok=True)
-
-        print('Installing Python server extension')
+        print('Installing Python module')
         install.run(self)
-
-        print('Installing notebook JS extension')
+        
+        print('Installing notebook extension')
         install_nbextension(EXT_DIR, overwrite=True, user=True)
+        cm = ConfigManager()
+        print('Enabling extension for notebook')
+        cm.update('notebook', {"load_extensions": {'urth_dash_js/notebook/main': True}})
 
-        print('Enabling notebook JS extension')
-        js_cm.update('notebook', {"load_extensions": {'urth_dash_js/notebook/main': True}})
+        print('Installing notebook server extension')
+        fn = os.path.join(jupyter_config_dir(), 'jupyter_notebook_config.py')
 
-        print('Enabling Python server extension')
-        cfg = server_cm.get('jupyter_notebook_config')
-        server_extensions = (
-            cfg.setdefault('NotebookApp', {})
-            .setdefault('server_extensions', [])
-        )
-        if 'urth.dashboard.nbexts' not in server_extensions:
-            cfg['NotebookApp']['server_extensions'] += ['urth.dashboard.nbexts']
-        server_cm.update('jupyter_notebook_config', cfg)
+        if os.path.isfile(fn):
+            with open(fn, 'r+') as fh:
+                lines = fh.read()
+                if SERVER_EXT_CONFIG not in lines:
+                    fh.seek(0, 2)
+                    fh.write('\n')
+                    fh.write(SERVER_EXT_CONFIG)
+        else:
+            with open(fn, 'w') as fh:
+                fh.write('c = get_config()\n')
+                fh.write(SERVER_EXT_CONFIG)
 
 setup(
     name='jupyter_dashboards',


### PR DESCRIPTION
Reverts JSON config switch made in issue #153 so that we don't clobber declarativewidgets or other projects. Does retain the fix for the missing config directories.

Will revisit #153 when we're ready to make the change en masse across all the associated extension projects. Don't want to block 0.3.0 on this which should primarily be about notebook 4.1 compatibility and for the separation of bundlers (#151).