### PR TITLE
[issue: 186] Incorrect urth-core-function syntax in meetup-streaming

### DIFF
--- a/etc/notebooks/stream_demo/meetup-streaming.ipynb
+++ b/etc/notebooks/stream_demo/meetup-streaming.ipynb
@@ -208,7 +208,7 @@
     "    <urth-core-function auto\n",
     "        id=\"set_topic_filter\"\n",
     "        ref=\"set_topic_filter\"\n",
-    "        arg-value$=\"[[topic_filter]]\">\n",
+    "        arg-value=\"{{topic_filter}}\">\n",
     "    </urth-core-function>\n",
     "        \n",
     "    <paper-input label=\"Filter\" value=\"{{topic_filter}}\"></paper-input>\n",


### PR DESCRIPTION
(c) Copyright IBM Corp. 2016