### PR TITLE
Report fix: proper empty cell computation

### DIFF
--- a/jupyter_dashboards/nbextension/notebook/dashboard-view/layout/grid/layout.js
+++ b/jupyter_dashboards/nbextension/notebook/dashboard-view/layout/grid/layout.js
@@ -67,8 +67,8 @@ define([
             ];
         }
 
-        // Must wait for CSS to be evaluated before we generate the grid. Otherwise, positioning
-        // is calculated incorrectly.
+        // Must wait for CSS to be evaluated before we generate the grid.
+        // Otherwise, positioning is calculated incorrectly.
         $.when.apply(null, cssLoaded).then(function() {
             var nolayout = this._addMetadataToDom(); // returns cells that don't have metadata
 

--- a/jupyter_dashboards/nbextension/notebook/dashboard-view/layout/report/layout.js
+++ b/jupyter_dashboards/nbextension/notebook/dashboard-view/layout/report/layout.js
@@ -26,33 +26,36 @@ define([
         this.$container = opts.$container;
 
         if (!cssLoaded) {
-            cssLoaded = [
-                linkCSS('./dashboard-view/layout/report/layout.css')
-            ];
+            cssLoaded = linkCSS('./dashboard-view/layout/report/layout.css');
         }
 
         Metadata.initialize({
             dashboardLayout: Metadata.DASHBOARD_LAYOUT.REPORT
         });
 
-        // setup cells for report layout
-        var self = this;
-        this.$container.find('.cell').each(function() {
-            var $cell = $(this);
+        $.when(cssLoaded).then(function() {
+            // setup cells for report layout
+            var self = this;
+            this.$container.find('.cell')
+                .css('min-height', '0px') // we detect empty cells by height
+                .each(function() {
+                    var $cell = $(this);
 
-            // hide cell if empty
-            if ($cell.height() === 0 && !Metadata.getCellLayout($cell)) {
-                Metadata.hideCell($cell);
-            }
+                    // hide cell if empty
+                    if ($cell.height() === 0 && !Metadata.getCellLayout($cell)) {
+                        Metadata.hideCell($cell);
+                    }
 
-            // set hidden state
-            $cell.toggleClass('dashboard-hidden dashboard-collapsed', !Metadata.isCellVisible($cell));
+                    // set hidden state
+                    $cell.toggleClass('dashboard-hidden dashboard-collapsed', !Metadata.isCellVisible($cell));
 
-            // add controle for hide, add, edit
-            self._addCellControls($cell);
+                    // add controle for hide, add, edit
+                    self._addCellControls($cell);
 
-            self._updateCollapseBtns();
-        });
+                    self._updateCollapseBtns();
+                })
+                .css('min-height','');
+        }.bind(this));
     }
 
     ReportLayout.prototype._addCellControls = function($cell) {


### PR DESCRIPTION
Problem: Transition between states like notebook -> report -> grid -> report and notice the empty cells aren't hidden
This is because we set min-height in CSS
This ensures empty cells are zero height