### PR TITLE
Notebook with report layout opens with button set to grid

### DIFF
--- a/jupyter_dashboards/nbextension/notebook/dashboard-view/dashboard-actions.js
+++ b/jupyter_dashboards/nbextension/notebook/dashboard-view/dashboard-actions.js
@@ -54,8 +54,8 @@ define([
             return /^fa-/.test(value);
         })[0];
     }
-
-    function updateAuthoringOptions(state) {
+    
+    function updateAuthoringButtonState(state) {
         if (state &&
             state !== STATE.NOTEBOOK &&
             state !== STATE.DASHBOARD_PREVIEW) {
@@ -70,6 +70,11 @@ define([
                     })
                     .addClass(icon);
         }
+    }
+
+    function updateAuthoringOptions(state) {
+        // update the layout button to reflect the current notebook layout mode
+        updateAuthoringButtonState(state);
 
         // enable the correct button group and menu state items
         var activeBtn = $(toolbarBtnsSelector + ' button:not(.dropdown-toggle)[data-dashboard-state="' + state + '"]');
@@ -199,6 +204,9 @@ define([
         });
         // update the authoring element based on current state
         updateAuthoringOptions(currentState);
+        // also set the initial layout button default to whatever layout the
+        // notebook currently has
+        updateAuthoringButtonState(Metadata.dashboardLayout);
     };
 
     DashboardActions.prototype.switchToNotebook = function() {


### PR DESCRIPTION
1. http://jupyter.cloudet.xyz/
2. Make a new notebook
3. Put print('hi') in a cell
4. Switch to **report** layout
5. Save
6. Refresh
7. Toolbar defaults to grid layout

Tested with v0.5.0