### PR TITLE
Cells are lost from report layout after refresh

### DIFF
--- a/jupyter_dashboards/nbextension/notebook/dashboard-view/dashboard-metadata.js
+++ b/jupyter_dashboards/nbextension/notebook/dashboard-view/dashboard-metadata.js
@@ -148,6 +148,9 @@ define([
     function _showCell(cells) {
         $(cells).each(function() {
             var metadata = _getCellMetadata($(this));
+            // add a layout object to indicate that this cell has explicitly 
+            // been added to the layout either by some initialization routine
+            // that calculated the layout or the user
             metadata.layout = {};
             delete metadata.hidden;
         });

--- a/jupyter_dashboards/nbextension/notebook/dashboard-view/layout/report/layout.js
+++ b/jupyter_dashboards/nbextension/notebook/dashboard-view/layout/report/layout.js
@@ -42,6 +42,9 @@ define([
                     // hide cell if empty
                     if ($cell.height() === 0 && !Metadata.getCellLayout($cell)) {
                         Metadata.hideCell($cell);
+                    } else {
+                        // explicitly call show if we're not hiding when we initialize
+                        Metadata.showCell($cell);
                     }
 
                     // set hidden state


### PR DESCRIPTION
Will provide reproducible test case and animation soon. Just noting that I hit the bug working on a notebook that I can't share.

Steps to reproduce:

1. Start a new notebook
2. print something.
3. Switch to report layout. Confirm the cell is included in the visible set.
4. Save
5. Switch to notebook.
6. Clear all output.
7. Save.
8. Refresh
9. Switch to report layout.
10. Notice the cell that was in the report layout is now marked as hidden.

Does not affect grid mode.