### PR TITLE
Include the license file

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
 recursive-include jupyter_dashboards *
+include LICENSE.md


### PR DESCRIPTION
This add the license file to `MANIFEST.in` to ensure it is packaged in the `sdist` or other packages.